### PR TITLE
Update config port option name

### DIFF
--- a/python/mailserver.py
+++ b/python/mailserver.py
@@ -124,7 +124,7 @@ if __name__ == '__main__':
     else :
         Config = ConfigParser.ConfigParser()
         Config.read("../config.ini")
-        port = int(Config.get("MAILSERVER","PORT"))
+        port = int(Config.get("MAILSERVER","MAILPORT"))
 
     
 


### PR DESCRIPTION
When running the Python file directly, Using `PORT` failed for me. Using `MAILPORT` which matches the config.ini worked.