### PR TITLE
Update mailserver.py

### DIFF
--- a/python/mailserver.py
+++ b/python/mailserver.py
@@ -89,7 +89,7 @@ class CustomSMTPServer(smtpd.SMTPServer):
 
             filenamebase = str(int(round(time.time() * 1000)))
 
-            for em in rcpttos:
+            for em.lower in rcpttos:
                 if not os.path.exists("../data/"+em):
                     os.mkdir( "../data/"+em, 0755 )
                 


### PR DESCRIPTION
Some sender will send emails to capitalized receiver mail.
The counterpart "is_dir" (php) is case sensitive on Unix-systems, so if you check mails for mymail@domain.tld you will not see mails sent to MYMAIL@DOMAIN.TLD.
This change will make sure that only lower-case is used to create a receiver-folder.