### PR TITLE
Fix the fix to path traversal attack, refactor

### DIFF
--- a/web/api.php
+++ b/web/api.php
@@ -27,7 +27,7 @@ switch($action)
             $o = explode(',',$settings['DOMAINS']);
     break;
     case 'attachment':
-        $id = $_REQUEST['id'];
+        $id = intval($_REQUEST['id']);
         $filename = basename(realpath($_REQUEST['filename']));
         $filepath = $dir.DS.'attachments'.DS.$id.'-'.$filename;
         if(!is_dir($dir))
@@ -45,7 +45,7 @@ switch($action)
     break;
 
     case 'load':
-        $id = $_REQUEST['id'];
+        $id = intval($_REQUEST['id']);
         if(empty($email))
             $o = array('status'=>'err','reason'=>'No email address provided');
         else if(!is_dir($dir))

--- a/web/api.php
+++ b/web/api.php
@@ -112,6 +112,5 @@ switch($action)
     break;
 }
 
-$o['email'] = $email;
 echo json_encode($o);
 //var_dump($o);

--- a/web/api.php
+++ b/web/api.php
@@ -112,5 +112,6 @@ switch($action)
     break;
 }
 
+$o['email'] = $email;
 echo json_encode($o);
 //var_dump($o);

--- a/web/inc/core.php
+++ b/web/inc/core.php
@@ -1,5 +1,10 @@
 <?php
 
+function getDirForEmail($email)
+{
+    return realpath(ROOT.DS.'..'.DS.'data'.DS.$email);
+}
+
 function startsWith($haystack, $needle)
 {
      $length = strlen($needle);
@@ -18,22 +23,22 @@ function endsWith($haystack, $needle)
 
 function getEmail($email,$id)
 {
-    return json_decode(file_get_contents(ROOT.DS.'..'.DS.'data'.DS.$email.DS.$id.'.json'),true);
+    return json_decode(file_get_contents(getDirForEmail($email).DS.$id.'.json'),true);
 }
 
 function emailIDExists($email,$id)
 {
-    return file_exists(ROOT.DS.'..'.DS.'data'.DS.$email.DS.$id.'.json');
+    return file_exists(getDirForEmail($email).DS.$id.'.json');
 }
 
 function getEmailsOfEmail($email)
 {
     $o = false;
-    if ($handle = opendir(ROOT.DS.'..'.DS.'data'.DS.$email)) {
+    if ($handle = opendir(getDirForEmail($email))) {
         while (false !== ($entry = readdir($handle))) {
             if (endsWith($entry,'.json')) {
                 $time = substr($entry,0,-5);
-                $json = json_decode(file_get_contents(ROOT.DS.'..'.DS.'data'.DS.$email.DS.$entry),true);
+                $json = json_decode(file_get_contents(getDirForEmail($email).DS.$entry),true);
                 $o[$time] = array('from'=>$json['parsed']['from'],'subject'=>$json['parsed']['subject']);
             }
         }


### PR DESCRIPTION
Fixes #29/#31, by:

* Adding a utility function to core to consistently get the email dir, and using it
* Using this function in the web API when testing if the directory exists
* Top-loading these safety checks in the API so we don't need to concatenate any potentially-unsafe paths in api.php itself
* Ensure that the `$id` is an integer (thanks @wr3nch0x1 for spotting this vector!), preventing it too from being used for path traversal attacks and providing an extra safety check that the format is as-expected