### PR TITLE
added "mkdir -p /run/nginx" to start.sh

### DIFF
--- a/docker/rootfs/start.sh
+++ b/docker/rootfs/start.sh
@@ -19,6 +19,7 @@ mkdir -p /var/log/nginx/opentrashmail
 touch /var/log/nginx/opentrashmail/web.access.log
 touch /var/log/nginx/opentrashmail/web.error.log
 
+mkdir -p /run/nginx
 nginx
 
 


### PR DESCRIPTION
This fixes an issue in kubernetes where the /run/nginx folder is missing on deployment.  
https://github.com/HaschekSolutions/opentrashmail/issues/74#issue-2060935772