### PR TITLE
Update OpenTrashmailBackend.class.php

### DIFF
--- a/web/inc/OpenTrashmailBackend.class.php
+++ b/web/inc/OpenTrashmailBackend.class.php
@@ -158,6 +158,7 @@ class OpenTrashmailBackend{
 
     function getAttachment($email,$attachment)
     {
+        $attachment = basename(urldecode($attachment));
         if(!filter_var($email, FILTER_VALIDATE_EMAIL))
             return $this->error('Invalid email address');
         else if(!attachmentExists($email,$attachment))


### PR DESCRIPTION
This fixes URL encoding issue with spaces when trying to download attachments. 
The basename(); should protect system from directory transversals.