### PR TITLE
[Feature] Auto refresh mail box

### DIFF
--- a/python/mailserver3.py
+++ b/python/mailserver3.py
@@ -274,10 +274,16 @@ if __name__ == '__main__':
         URL = Config.get("GENERAL", "URL")
         if("attachments_max_size" in Config.options("MAILSERVER")):
             ATTACHMENTS_MAX_SIZE = int(Config.get("MAILSERVER", "ATTACHMENTS_MAX_SIZE"))
-
-        if("CLEANUP" in Config.sections() and "delete_older_than_days" in Config.options("CLEANUP")):
-            DELETE_OLDER_THAN_DAYS = Config.getfloat("CLEANUP", "DELETE_OLDER_THAN_DAYS")
-
+        if "CLEANUP" in Config.sections() and "delete_older_than_days" in Config.options("CLEANUP"):
+            raw_val = Config.get("CLEANUP", "DELETE_OLDER_THAN_DAYS").strip().lower()
+            try:
+                if raw_val in ["false", "off", "no", "none"]:
+                    DELETE_OLDER_THAN_DAYS = 0
+                else:
+                    DELETE_OLDER_THAN_DAYS = float(raw_val)
+            except ValueError:
+                logger.warning("Invalid value for DELETE_OLDER_THAN_DAYS: %s. Defaulting to 0." % raw_val)
+                DELETE_OLDER_THAN_DAYS = 0
         if("mailport_tls" in Config.options("MAILSERVER")):
             MAILPORT_TLS = int(Config.get("MAILSERVER", "MAILPORT_TLS"))
         if("tls_certificate" in Config.options("MAILSERVER")):

--- a/web/templates/index.html.php
+++ b/web/templates/index.html.php
@@ -24,10 +24,18 @@
 
   <button class="htmx-indicator" aria-busy="true">Loading…</button>
 
-  <main id="main" class="container" hx-get="/api/<?= $url ?>" hx-trigger="load">
+  <main id="main" class="container" hx-get="/api/<?= $url ?>" hx-trigger="load, every30s from:body">
 
   </main>
-
+  <script>
+    function pollIfVisible() {
+      if (document.visibilityState === 'visible') {
+        htmx.trigger(document.body, "every30s");
+      }
+    }
+    document.addEventListener("visibilitychange", pollIfVisible);
+    setInterval(pollIfVisible, 30000);
+  </script>
   <script src="/js/opentrashmail.js"></script>
   <script src="/js/htmx.min.js"></script>
   <script src="/js/moment-with-locales.min.js"></script>


### PR DESCRIPTION
This feature auto refreshes the mail list every 30 sec to check for new mail.
#TODO add enable/disable to config and timer set

@geek-at Should I have it pull the api json and if that change reload content outside of htmx? or push it using raw ajax? I'm use to raw ajax not htmx.