### PR TITLE
Issue 101

### DIFF
--- a/python/mailserver3.py
+++ b/python/mailserver3.py
@@ -333,6 +333,7 @@ class CustomHandler:
         return html_content
 
 def cleanup():
+    global LAST_CLEANUP
     if(DELETE_OLDER_THAN_DAYS == False or time.time() - LAST_CLEANUP < 86400):
         return
     logger.info("Cleaning up")


### PR DESCRIPTION
LAST_CLEANUP causes UnboundLocalError due to missing global declaration in cleanup()

For Details https://github.com/HaschekSolutions/opentrashmail/issues/101